### PR TITLE
Fix link underlining CSS

### DIFF
--- a/website/src/css/markdown.css
+++ b/website/src/css/markdown.css
@@ -3,7 +3,7 @@
   text-decoration: none;
   background-image: url('data:image/svg+xml;utf8,<svg preserveAspectRatio="none" viewBox="0 0 1 1" xmlns="http://www.w3.org/2000/svg"><line x1="0" y1="0" x2="1" y2="1" stroke="rgba(84,110,122 ,1)" /></svg>');
   background-size: 1px 1px;
-  background-position: 0 calc(1em + 1px);
+  background-position: 0 1.2em;
   font-weight: 500;
   background-repeat: repeat-x;
 }


### PR DESCRIPTION
This change adds a little bit of space between the text baseline and the
link underline, to help with readability.

Tested with:
```
$ yarn build
yarn run v1.22.15
$ docusaurus build
[INFO] [en] Creating an optimized production build...

✔ Client
  

✔ Server
  Compiled successfully in 4.53s


✔ Client
  

● Server █████████████████████████ cache (99%) shutdown IdleFileCachePlugin
 stored

[Local Search] [INFO]: Gathering documents
[Local Search] [INFO]: Parsing documents
[Local Search] [INFO]: 3 indexes will be created.
[Local Search] [INFO]: Building index blog_posts_list (20 documents)
[Local Search] [INFO]: Building index default (193 documents)
[Local Search] [INFO]: Building index docs-default-current (57 documents)
[Local Search] [INFO]: Index blog_posts_list written to disk
[Local Search] [INFO]: Index docs-default-current written to disk
[Local Search] [INFO]: Index default written to disk
[SUCCESS] Generated static files in build.
[INFO] Use `npm run serve` command to test your build locally.
Done in 8.03s.
$ yarn run v1.22.15
$ docusaurus serve
[SUCCESS] Serving build directory at http://localhost:3000/.
```

Example - before:
![link_current](https://user-images.githubusercontent.com/67685450/153029282-3a6743e3-532e-45a4-ae51-e32d19ed1bc8.png)

Example - after:
![link_1 2em](https://user-images.githubusercontent.com/67685450/153029380-b587a2be-b064-4184-a6e4-8f033919af1e.png)


