### PR TITLE
Added Cell Tower SVG to frontpage

### DIFF
--- a/website/src/components/hero/celltower-svg/celltower-svg.tsx
+++ b/website/src/components/hero/celltower-svg/celltower-svg.tsx
@@ -1,0 +1,189 @@
+import React from "react"
+import styles from "./celltower.module.css"
+
+function Component() {
+  return (
+    <svg
+      className={styles["celltower-svg"]}
+      xmlns="http://www.w3.org/2000/svg"
+      id="svg5"
+      version="1.1"
+      viewBox="0 0 127 153"
+      xmlSpace="preserve"
+    >
+      <g id="celltower">
+        <g
+          id="layer3"
+          fill="#fff"
+          stroke="#1a1a1a"
+          display="inline"
+          transform="translate(-42.1 -65.3)"
+        >
+          <g id="mount3" transform="translate(8.5 9.4) scale(.94181)">
+            <path
+              id="radio3"
+              strokeWidth="0.265"
+              d="M86.2 94.3l1.2-.6 3.4.6v16l-1.3.4-3.3-.5z"
+              display="inline"
+            ></path>
+            <path
+              id="mount3box"
+              strokeWidth="0.254"
+              d="M88.8 96.3l.2-.1.6.2v20h-.3l-.5-.1z"
+              display="inline"
+            ></path>
+          </g>
+          <path
+            id="mount4"
+            strokeWidth="0.236"
+            d="M105.3 102.6h.7v19.2h-.7z"
+            display="inline"
+          ></path>
+          <g id="rails" strokeWidth="0.265">
+            <path
+              id="rail1"
+              d="M87.7 100.3l-.4.8 29.8 6.5v-.7z"
+              display="inline"
+            ></path>
+            <path
+              id="rail2"
+              d="M117.2 91.9l-1 .1.1.8-.1 25.9.5-11v10.9z"
+              display="inline"
+            ></path>
+            <path
+              id="rail3"
+              d="M87.2 100.3v.8l.8.1 29.3-8.6V92l-.6-.3z"
+              display="inline"
+            ></path>
+          </g>
+          <path
+            id="base_plate"
+            strokeWidth="0.265"
+            d="M97.9 115.6l18.5 4.2 1.2-.4v-14.3l-2.1-.8-25 7.4v2.3z"
+            display="inline"
+          ></path>
+          <g id="radio2" transform="translate(-.5 -1.3)">
+            <path
+              id="mount2"
+              strokeWidth="0.268"
+              d="M116.7 88.5l.4-.1h.4v24.2h-.1l-.7-.1z"
+              display="inline"
+            ></path>
+            <path
+              id="radio2box"
+              strokeWidth="0.31"
+              d="M115.3 86l1.6-.8 3.8 1.6.1 17-1.3.6-4.2-1.3z"
+            ></path>
+          </g>
+          <path
+            id="baseplatemini"
+            strokeWidth="0.166"
+            d="M103.1 114.7l11.5 3 .9-.2v-8.7l-1.7-.5-17.4 4.1v.8z"
+            display="inline"
+          ></path>
+          <path
+            id="mount5"
+            strokeWidth="0.276"
+            d="M108 113h.8V90.9l-.1-.2-.7.1z"
+            display="inline"
+          ></path>
+        </g>
+        <g id="legs" display="inline" transform="translate(-43 -65)">
+          <path
+            id="baseplatemaxi"
+            fill="#fff"
+            stroke="#1a1a1a"
+            strokeWidth="0.432"
+            d="M97.7 210.8l27.4 7 5-1 1-20.7-4.2-.6-49.4 9v1.6z"
+            display="inline"
+          ></path>
+          <path
+            id="rearleg"
+            fill="#fff"
+            stroke="#1a1a1a"
+            strokeWidth="0.265"
+            d="M114.3 115.8l1-.3 1 1.7 14.8 78.7-3 3-2-.6z"
+            display="inline"
+          ></path>
+          <g
+            id="sticks"
+            display="inline"
+            transform="matrix(1.01786 0 0 -1.01786 -1 337.7)"
+          >
+            <path
+              id="baseplate"
+              fill="#fff"
+              stroke="#1a1a1a"
+              strokeWidth="0.265"
+              d="M96.6 161.6l19.8 2.7 2-.4.7-7.9-2.2-1.3-27.7 3.5v2.3z"
+              display="inline"
+            ></path>
+          </g>
+          <path
+            id="leftleg"
+            fill="#fff"
+            stroke="#1a1a1a"
+            strokeWidth="0.265"
+            d="M97.3 112.2h2.6v.8l-14.7 93.2h-7.9v-2z"
+            display="inline"
+          ></path>
+          <path
+            id="rightleg"
+            fill="#fff"
+            stroke="#1a1a1a"
+            strokeWidth="0.265"
+            d="M113.5 109.3l1.2-1 1.5.3L130 217l-5 1-5-5.2z"
+            display="inline"
+          ></path>
+        </g>
+        <g
+          id="radio1"
+          fill="#fff"
+          stroke="#1a1a1a"
+          display="inline"
+          transform="matrix(1.15804 0 0 1.03418 -55.9 -67.1)"
+        >
+          <path
+            id="mount1"
+            strokeWidth="0.253"
+            d="M96.9 93.7l.1-.2.6.1v20h-.7z"
+            display="inline"
+          ></path>
+          <path
+            id="radio1box"
+            strokeWidth="0.265"
+            d="M94.7 91.1l3.6-.9.7.5V107l-3.3.8-.9-.5z"
+          ></path>
+        </g>
+      </g>
+      <g id="waves" transform="translate(-43 -65)">
+        <g id="w1">
+          <path id="wave_l1" d="M75.3 120.8a32.6 32.6 0 010-29"></path>
+          <path
+            id="wave_r1"
+            d="M75.3 120.8a32.6 32.6 0 010-29"
+            transform="matrix(-1 0 0 1 211.4 -5.7)"
+          ></path>
+        </g>
+        <g id="w2">
+          <path id="wave_l2" d="M63.8 130a53.5 53.5 0 010-47.6"></path>
+          <path
+            id="wave_r2"
+            d="M63.8 130a53.5 53.5 0 010-47.6"
+            transform="matrix(-1 0 0 1 211.4 -5.7)"
+          ></path>
+        </g>
+        <g id="w3">
+          <path id="wave_l3" d="M51.8 73a74.2 74.2 0 000 66"></path>
+          <path
+            id="wave_r3"
+            d="M51.8 73a74.2 74.2 0 000 66"
+            transform="matrix(-1 0 0 1 211.4 -5.7)"
+          ></path>
+        </g>
+      </g>
+    </svg>
+  )
+}
+
+export default Component

--- a/website/src/components/hero/celltower-svg/celltower.module.css
+++ b/website/src/components/hero/celltower-svg/celltower.module.css
@@ -1,0 +1,102 @@
+.celltower-svg {
+  --line-color: #27343a;
+  --wave-color: #b3e5fc;
+  --thickness-wave-1: 1.8267;
+  --thickness-wave-2: 3;
+  --thickness-wave-3: 4.16159;
+
+  min-height: 300px;
+}
+
+.celltower-svg :global(#waves) {
+  border: 5px solid blue !important;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-opacity: 1;
+  display: inline;
+  fill: none;
+  paint-order: normal;
+}
+
+.celltower-svg :global(#w1) {
+  stroke: var(--wave-color);
+  stroke-width: var(--thickness-wave-1);
+}
+
+.celltower-svg :global(#w2) {
+  stroke: var(--wave-color);
+  stroke-width: var(--thickness-wave-2);
+}
+
+.celltower-svg :global(#w3) {
+  stroke: var(--wave-color);
+  stroke-width: var(--thickness-wave-3);
+}
+
+.celltower-svg :global(#wave_l1) {
+  opacity: 0;
+  transform: translate(5px, -4px);
+  animation: wave-anim-left 3s ease forwards infinite;
+  animation-delay: 0s;
+}
+
+.celltower-svg :global(#wave_l2) {
+  opacity: 0;
+  transform: translate(5px, -4px);
+  animation: wave-anim-left 3s ease forwards infinite;
+  animation-delay: 500ms;
+}
+
+.celltower-svg :global(#wave_l3) {
+  opacity: 0;
+  transform: translate(5px, -4px);
+  animation: wave-anim-left 3s ease forwards infinite;
+  animation-delay: 1000ms;
+}
+
+.celltower-svg :global(#wave_r1) {
+  opacity: 0;
+  transform: matrix(-1, 0, 0, 1, 206.43, -4);
+  animation: wave-anim-right 3s ease forwards infinite;
+  animation-delay: 0s;
+}
+
+.celltower-svg :global(#wave_r2) {
+  opacity: 0;
+  transform: matrix(-1, 0, 0, 1, 206.43, -4);
+  animation: wave-anim-right 3s ease forwards infinite;
+  animation-delay: 500ms;
+}
+
+.celltower-svg :global(#wave_r3) {
+  opacity: 0;
+  transform: matrix(-1, 0, 0, 1, 206.43, -4);
+  animation: wave-anim-right 3s ease forwards infinite;
+  animation-delay: 1000ms;
+}
+
+@keyframes wave-anim-left {
+  50% {
+    transform: translate(3px, -4px);
+    opacity: 1;
+  }
+
+  70%,
+  100% {
+    transform: translate(0px, -4px);
+    opacity: 0;
+  }
+}
+
+@keyframes wave-anim-right {
+  50% {
+    transform: matrix(-1, 0, 0, 1, 208.43, -4);
+    opacity: 1;
+  }
+
+  70%,
+  100% {
+    transform: matrix(-1, 0, 0, 1, 211.43, -4);
+    opacity: 0;
+  }
+}

--- a/website/src/components/hero/hero.tsx
+++ b/website/src/components/hero/hero.tsx
@@ -1,8 +1,10 @@
 import React from "react"
 import styles from "./hero.module.css"
 import common from "../../css/common.module.css"
+import celltowerstyle from "./celltower.module.css"
 import Translate from "@docusaurus/Translate"
 import Link from "@docusaurus/Link"
+import CellTowerSvg from "./celltower-svg/celltower-svg"
 
 function Component() {
   return (
@@ -37,6 +39,9 @@ function Component() {
               Request a Demo
             </Link>
           </div>
+        </div>
+        <div>
+          <CellTowerSvg />
         </div>
       </div>
     </div>

--- a/website/src/components/hero/hero.tsx
+++ b/website/src/components/hero/hero.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import styles from "./hero.module.css"
 import common from "../../css/common.module.css"
-import celltowerstyle from "./celltower.module.css"
 import Translate from "@docusaurus/Translate"
 import Link from "@docusaurus/Link"
 import CellTowerSvg from "./celltower-svg/celltower-svg"


### PR DESCRIPTION
Adds an inline SVG of a cell tower with animation, and scales to fit mobile view as well

- New sub-component: `celltower-svg` added, under `hero` component.
  - Q: would it be better to have it in the root `/components` folder, or leave it here to not make things cluttered?