### PR TITLE
Fix broken (404) links

### DIFF
--- a/website/src/components/casestudy/casestudy-list.tsx
+++ b/website/src/components/casestudy/casestudy-list.tsx
@@ -31,7 +31,7 @@ const caseStudies = [
     ),
   },
   {
-    name: "Mobile Network Operators",
+    name: "Small Operators",
     description: (
       <Translate
         id="home.casestudy.smalloperators.description"
@@ -102,7 +102,7 @@ function Component(props) {
             {caseStudy.description}
           </div>
           <a
-            href={`/docs/case-studies/${caseStudy.name.replace(/ /g, "-")}`}
+            href={`/docs/case-studies/${caseStudy.name.toLowerCase().replace(/ /g, "-")}`}
             className={styles.link}
           >
             <Translate

--- a/website/src/components/casestudy/casestudy-list.tsx
+++ b/website/src/components/casestudy/casestudy-list.tsx
@@ -102,7 +102,9 @@ function Component(props) {
             {caseStudy.description}
           </div>
           <a
-            href={`/docs/case-studies/${caseStudy.name.toLowerCase().replace(/ /g, "-")}`}
+            href={`/docs/case-studies/${caseStudy.name
+              .toLowerCase()
+              .replace(/ /g, "-")}`}
             className={styles.link}
           >
             <Translate


### PR DESCRIPTION
The `name` field in casestudy-list.tsx happens to kinda match the id of
the articles in docs/case-studies. So it kinda works. Except it doesn't
lowercase and one name doesn't match.

This isn't great, but this commit does a quick fix, at least.
