### PR TITLE
Add PR Title to Dev site

### DIFF
--- a/.github/workflows/website-dev-pages.yml
+++ b/.github/workflows/website-dev-pages.yml
@@ -23,19 +23,17 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
+      - name: Replace Title with PR Name
+        run: |
+          num="${{ github.event.pull_request.number }}"
+          title="${{ github.event.pull_request.title }}"
+          sed -Ei "s/title:.*\"(.*)\"/title: \"$title (#$num)\"/" website/docusaurus.config.js
+
       - name: Prettier & Build Website
         run: |
           cd website
           yarn install && yarn prettier
-          if [ ! -n "$(git status --porcelain)" ]; then
-            yarn buildDevpage
-            exit 0
-          fi
-          git config --global user.name 'GitHub Action'
-          git config --global user.email 'github-action@users.noreply.github.com'
-          git commit -am "[Prettier] Fix formatting"
-          git push
-          exit 1
+          yarn buildDevpage
 
       - name: Deploy Website 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.0

--- a/website/src/pages/test.tsx
+++ b/website/src/pages/test.tsx
@@ -1,7 +1,0 @@
-import React from "react"
-
-function Component() {
-  return <h1>Test version 2 ⭐</h1>
-}
-
-export default Component

--- a/website/src/pages/test.tsx
+++ b/website/src/pages/test.tsx
@@ -1,0 +1,7 @@
+import React from "react"
+
+function Component() {
+  return <h1>Test version 2 ⭐</h1>
+}
+
+export default Component


### PR DESCRIPTION
With multiple PRs with `devpages` label, an easy way was needed to identify _which_ PR the dev site had deployed the build of. So I modified the Github Action so that the **page title** gets the **PR _name_** and **_number_** appended (hover tab with cursor to see):

![image](https://user-images.githubusercontent.com/27897747/191657871-ffa51db7-ed6f-4b18-97e3-b509452f5bbd.png)

