### PR TITLE
Update website-sync-personio-jobs.yml so it doesn't spam my commit history

### DIFF
--- a/.github/workflows/website-sync-personio-jobs.yml
+++ b/.github/workflows/website-sync-personio-jobs.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           delete-branch: true
           commit-message: "[autosync] Update personio job list"
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
       - name: Enable Automerge on PR
         if: steps.cpr.outputs.pull-request-operation == 'created'
         uses: peter-evans/enable-pull-request-automerge@v2


### PR DESCRIPTION
This pipeline has been commiting as me. Let's change this ;) 

The changes reference config found https://github.com/peter-evans/enable-pull-request-automerge/blob/main/.github/workflows/ci.yml#L71-L72

16,197 times to be exact
<img width="1288" alt="image" src="https://user-images.githubusercontent.com/39831372/194612550-d0833496-938a-47b7-baf2-df13e9fc0d3e.png">
<img width="1199" alt="image" src="https://user-images.githubusercontent.com/39831372/194612593-7a232874-3222-422e-8006-01dbe44af356.png">
