### PR TITLE
[GH Action] Auto-Commit Prettier for PR

### DIFF
--- a/.github/workflows/website-pr.yml
+++ b/.github/workflows/website-pr.yml
@@ -16,6 +16,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'website skip')"
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'

--- a/.github/workflows/website-pr.yml
+++ b/.github/workflows/website-pr.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - test-gh-branch
+      - 'test-gh-branch'
     paths:
       - "docs/**"
       - "blog/**"

--- a/.github/workflows/website-pr.yml
+++ b/.github/workflows/website-pr.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - 'test-gh-branch'
+      - 'pr-auto-commit-prettier'
     paths:
       - "docs/**"
       - "blog/**"

--- a/.github/workflows/website-pr.yml
+++ b/.github/workflows/website-pr.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - test-gh-branch
     paths:
       - "docs/**"
       - "blog/**"

--- a/.github/workflows/website-pr.yml
+++ b/.github/workflows/website-pr.yml
@@ -21,5 +21,12 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Prettier & Build & Test for broken links
         run: |
-          cd website 
-          yarn && yarn prettier:check && yarn build && yarn links:test
+          cd website
+          yarn prettier
+          if [ -n "$(git status --porcelain)" ]; then
+            git config --global user.name 'GitHub Action'
+            git config --global user.email 'github-action@users.noreply.github.com'
+            git commit -am "[Prettier] Fix formatting"
+            git push
+          fi
+          yarn && yarn build && yarn links:test


### PR DESCRIPTION
Runs `yarn prettier` and check if any files were modified, and if they were, commits those changes and pushes, and proceeds with normal procedure.

> Note: a user would have to manually fetch origin for new changes when developing locally (such as when using Github Desktop), and this isn't evident so a user _can_ make more changes locally and push those, only to be met with a warning that there are unfetched commits from origin. Hopefully this isn't a big issue 😅
> 
> ![image](https://user-images.githubusercontent.com/27897747/203394177-636f49c8-855e-427c-a215-6d87a97673c6.png)
