### PR TITLE
[Fixed] Incorrect Meta/Head Links

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -5,7 +5,7 @@ module.exports = {
   title: "Working Group Two",
   tagline:
     "No more boxes, no more end of life, no large upfront investments. With the wgtwo cloud native mobile core we offer continuous innovation, continuous development, scalability and flexibility. And to make it really simple for operators – delivered as a managed SaaS telecommunication network.",
-  url: "https://www.wgtwo.com/",
+  url: "https://www.wgtwo.com",
   baseUrl: "/",
   favicon: "img/favicons/favicon.ico",
   organizationName: "working-group-two",


### PR DESCRIPTION
#### `wgtwo.com//blog` ➞ `wgtwo.com/blog`