### PR TITLE
[Bugfix] Devpages Title: only replace first occurrence

### DIFF
--- a/.github/workflows/website-dev-pages.yml
+++ b/.github/workflows/website-dev-pages.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           num="${{ github.event.pull_request.number }}"
           title="${{ github.event.pull_request.title }}"
-          sed -Ei "s/title:.*\"(.*)\"/title: \"$title (#$num)\"/" website/docusaurus.config.js
+          sed -Ei "0,/title:/{s/title:.*\"(.*)\"/title: \"$title (#$num)\"/}" website/docusaurus.config.js
 
       - name: Prettier & Build Website
         run: |


### PR DESCRIPTION
The code that adds the PR name to the Title also targeted the Footer Titles. So I've changed to only target the _first occurrence_

Bug:
![image](https://user-images.githubusercontent.com/27897747/211370707-24494933-dfb6-4e43-8052-b31fd470867d.png)
