### PR TITLE
Remove GA3

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -236,9 +236,6 @@ module.exports = {
           editUrl:
             "https://github.com/working-group-two/wgtwo.com/edit/main/blog/",
         },
-        googleAnalytics: {
-          trackingID: "UA-114662288-1",
-        },
         theme: {
           customCss: [
             require.resolve("./src/css/footer.css"),


### PR DESCRIPTION
We adopted GA4 via GTM (google tag manager) and this removes the GA3 integration.