### PR TITLE
[gh-actions] update to newer versions to fix deprecation warnings

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -17,9 +17,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/website-dev-pages.yml
+++ b/.github/workflows/website-dev-pages.yml
@@ -16,9 +16,9 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'devpages')
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/website-pr.yml
+++ b/.github/workflows/website-pr.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'website skip')"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/website-sync-personio-jobs.yml
+++ b/.github/workflows/website-sync-personio-jobs.yml
@@ -31,7 +31,7 @@ jobs:
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           merge-method: squash
       #--- start copy from website-deploy.yml
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/website/src/pages/security.tsx
+++ b/website/src/pages/security.tsx
@@ -36,7 +36,7 @@ function Index() {
       setFormErrorEmail(true)
       setFormError(
         translate({
-          message: "Email address is invalid",
+          message: "Email address is invalid, try again",
           id: "contact.form.invalidEmail",
           description: "Error message when the email address is invalid",
         })

--- a/website/src/pages/security.tsx
+++ b/website/src/pages/security.tsx
@@ -36,10 +36,10 @@ function Index() {
       setFormErrorEmail(true)
       setFormError(
         translate({
-          message: "Email address is invalid, try again",
+          message: "Email address is invalid",
           id: "contact.form.invalidEmail",
           description:
-            "Error message when the email address is invalid, try again",
+            "Error message when the email address is invalid",
         })
       )
       return

--- a/website/src/pages/security.tsx
+++ b/website/src/pages/security.tsx
@@ -38,8 +38,7 @@ function Index() {
         translate({
           message: "Email address is invalid",
           id: "contact.form.invalidEmail",
-          description:
-            "Error message when the email address is invalid",
+          description: "Error message when the email address is invalid",
         })
       )
       return

--- a/website/src/pages/security.tsx
+++ b/website/src/pages/security.tsx
@@ -38,7 +38,8 @@ function Index() {
         translate({
           message: "Email address is invalid, try again",
           id: "contact.form.invalidEmail",
-          description: "Error message when the email address is invalid, try again",
+          description:
+            "Error message when the email address is invalid, try again",
         })
       )
       return

--- a/website/src/pages/security.tsx
+++ b/website/src/pages/security.tsx
@@ -38,7 +38,7 @@ function Index() {
         translate({
           message: "Email address is invalid, try again",
           id: "contact.form.invalidEmail",
-          description: "Error message when the email address is invalid",
+          description: "Error message when the email address is invalid, try again",
         })
       )
       return


### PR DESCRIPTION
Fix node 12 deprecation warnings for github actions by upgrading to the latest version

https://github.com/working-group-two/wgtwo.com/actions/runs/4321677432
<img width="969" alt="image" src="https://user-images.githubusercontent.com/39831372/222678561-71c20b3c-3573-4f89-92e6-6988405f8850.png">
