### PR TITLE
Pimp the Blog Post Items

### DIFF
--- a/website/src/theme/BlogLayout/styles.module.css
+++ b/website/src/theme/BlogLayout/styles.module.css
@@ -47,7 +47,6 @@
   margin-left: calc(0.5 / 12 * 100%);
 }
 
-
 /* ANIMATIONS */
 @keyframes fadeUp {
   0% {

--- a/website/src/theme/BlogLayout/styles.module.css
+++ b/website/src/theme/BlogLayout/styles.module.css
@@ -1,5 +1,5 @@
 .blogBackground {
-  background-color: #f7f7f7;
+  background-color: #eff3f6;
 }
 
 /* BLOG OVERVIEW - CARD LIST VIEW */
@@ -27,6 +27,7 @@
 /* SINGLE BLOG POST PAGE VIEW */
 
 .singleBlogPageView {
+  animation: fadeUp 200ms ease;
 }
 
 /* NAV OVERRIDE - NEXT/PREV ARTICLE BTNS */
@@ -44,4 +45,16 @@
 }
 .colOffset2 {
   margin-left: calc(0.5 / 12 * 100%);
+}
+
+
+/* ANIMATIONS */
+@keyframes fadeUp {
+  0% {
+    opacity: 0.2;
+    transform: translateY(10px);
+  }
+  100% {
+    opacity: 1;
+  }
 }

--- a/website/src/theme/BlogPostItem/Container/styles.module.css
+++ b/website/src/theme/BlogPostItem/Container/styles.module.css
@@ -32,18 +32,24 @@ a.avatar__photo-link {
 
 .articleContainer {
   background-color: white;
-  border: 1px solid #c9ced7;
-  border-radius: 10px;
-  padding: 35px 50px;
-  padding-bottom: 40px;
+  border: 1px solid #f1f2f4;
+  border-radius: 2px;
+  padding: 75px 90px 40px;
+  padding-bottom: 50px;
   box-shadow: 0px 5px 20px #a6b8c661;
 }
 
 /* Mobile View */
+@media (max-width: 900px) {
+  /* Blog Post Page View */
+  .articleContainer {
+    padding: 50px 60px 20px 60px;
+  }
+}
 @media (max-width: 600px) {
   /* Blog Post Page View */
   .articleContainer {
-    padding: 15px 20px; /*25px 30px;*/
+    padding: 30px 40px 30px 40px;
   }
 
   .articleContainer h1 {


### PR DESCRIPTION
See this link for the changes made: https://github.com/working-group-two/wgtwo.com/issues/320#issuecomment-1529309389

The fade animation is exclusively kept for the individual blog posts, _not_ the main blog overview page.