### PR TITLE
Improve email regex for contact form

### DIFF
--- a/website/src/components/contact-form/contact-form.tsx
+++ b/website/src/components/contact-form/contact-form.tsx
@@ -32,7 +32,7 @@ function Contact() {
     if (!validEmail(form.email.current.value)) {
       setEmailError(
         translate({
-          message: "Email address is invalid",
+          message: "Email address is invalid. Please use a company email.",
           id: "contact.form.invalidEmail",
           description: "Error message when the email address is invalid",
         })

--- a/website/src/pages/contact.tsx
+++ b/website/src/pages/contact.tsx
@@ -37,7 +37,7 @@ function Contact() {
       setFormErrorEmail(true)
       setFormError(
         translate({
-          message: "Email address is invalid",
+          message: "Email address is invalid. Please use a company email.",
           id: "contact.form.invalidEmail",
           description: "Error message when the email address is invalid",
         })

--- a/website/src/pages/request-demo.tsx
+++ b/website/src/pages/request-demo.tsx
@@ -38,7 +38,7 @@ function RequestDemo() {
       setFormErrorEmail(true)
       setFormError(
         translate({
-          message: "Email address is invalid",
+          message: "Email address is invalid. Please use a company email.",
           id: "contact.form.invalidEmail",
           description: "Error message when the email address is invalid",
         })

--- a/website/src/pages/security.tsx
+++ b/website/src/pages/security.tsx
@@ -36,7 +36,7 @@ function Index() {
       setFormErrorEmail(true)
       setFormError(
         translate({
-          message: "Email address is invalid",
+          message: "Email address is invalid. Please use a company email.",
           id: "contact.form.invalidEmail",
           description: "Error message when the email address is invalid",
         })

--- a/website/src/pages/technology.tsx
+++ b/website/src/pages/technology.tsx
@@ -55,7 +55,7 @@ function Index() {
       setFormErrorEmail(true)
       setFormError(
         translate({
-          message: "Email address is invalid",
+          message: "Email address is invalid. Please use your company email.",
           id: "contact.form.invalidEmail",
           description: "Error message when the email address is invalid",
         })

--- a/website/src/util/helpers.js
+++ b/website/src/util/helpers.js
@@ -1,5 +1,8 @@
 module.exports = {
-  validEmail: email => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email),
+  validEmail: email =>
+    /^[^\s@]+@(?!gmail\.com|yahoo\.com|hotmail\.com|outlook\.com|aol\.com|icloud\.com|zoho\.com|protonmail\.com|gmx\.com|yandex\.com|mail\.com|temp-mail\.org|guerrillamail\.com|10minutemail|mailinator\.com|yopmail\.com|throwawaymail\.com|fakemailgenerator\.com|getnada\.com|tempinbox\.com|mintemail\.com|mailcatch\.com|owlymail\.com|fakeinbox\.com|mytempemail\.com|trashmail\.com|spamgourmet\.com|jetable\.org|mailnesia\.com|inboxbear\.com|mailtemp\.org|mailslurp\.com|33mail\.com|guerrillamail\.net|maildrop\.cc|sharklasers\.com|tempail\.com|spamgourmet\.net|dispostable\.com|tempmailo\.com|mailnesia\.com|getairmail\.com|inboxalias\.com|email\.tst|oastify\.com)[^\s@]+\.[^\s@]+$/i.test(
+      email
+    ),
   containsAngleBrackets: string => /[<>]+/.test(string),
   slugify: text =>
     text


### PR DESCRIPTION
Help block spam by improving the denylist to include popular email clients like gmail and yahoo, as well as, popular one time email providers that are commonly used by malicious purposes. In the future, we can continue to update this list if we find new domains we should block.