### PR TITLE
[Fix] Showcase page Mobile view Pill Visibility

### DIFF
--- a/website/src/pages/showcase/components/bigTitle.module.css
+++ b/website/src/pages/showcase/components/bigTitle.module.css
@@ -1,8 +1,3 @@
-.pill {
-  position: absolute;
-  top: -50px;
-}
-
 .header {
   display: flex;
   /*margin-bottom: var(--ifm-heading-margin-bottom);*/
@@ -32,5 +27,12 @@
 
   .logoContainer {
     display: block;
+  }
+}
+
+@media (min-width: 1200px) {
+  .pill {
+    position: absolute;
+    top: -50px;
   }
 }


### PR DESCRIPTION
The blue pill (e.g. "MVO") in the showcase pages wasn't mobile-friendly, so I fixed that :)