### PR TITLE
Protect Netlify files in Dev-Pages Branch

### DIFF
--- a/.github/workflows/website-dev-pages.yml
+++ b/.github/workflows/website-dev-pages.yml
@@ -40,3 +40,6 @@ jobs:
         with:
           branch: dev-pages
           folder: website/build
+          clean-exclude: |
+            package.json
+            netlify


### PR DESCRIPTION
Exclude the Netlify files and folders from being wiped upon deployment of a branch for testing.

Excluded items:
- package.json (used to install sendgrid dependency)
- netlify folder (contains sendmail function)