### PR TITLE
Remove Storefront links and references

### DIFF
--- a/docs/about/demos.md
+++ b/docs/about/demos.md
@@ -20,11 +20,6 @@ https://developer.wgtwo.com
 Telecom operators on the **wgtwo** platform are able to configure their own subscriptions, giving them the freedom to add the products that meets their needs.  
 https://console.wgtwo.com
 
-#### Storefront
-
-Your platform to market your application to customers across **wgtwo** operators.  
-https://storefront.wgtwo.com
-
 #### Softphone
 
 Imagine making a GSM call through your browser.  

--- a/website/src/pages/product-ecosystem.tsx
+++ b/website/src/pages/product-ecosystem.tsx
@@ -284,7 +284,7 @@ function Index() {
               <div className={styles.price}>Find a new app today</div>
               <div
                 className={`${common.button} ${common.buttonPrimary}`}
-                style={{background: '#aaaaaa'}}
+                style={{ background: "#aaaaaa" }}
               >
                 Storefront
               </div>

--- a/website/src/pages/product-ecosystem.tsx
+++ b/website/src/pages/product-ecosystem.tsx
@@ -282,13 +282,12 @@ function Index() {
                 />
               </div>
               <div className={styles.price}>Find a new app today</div>
-              <a
+              <div
                 className={`${common.button} ${common.buttonPrimary}`}
-                href="https://storefront.wgtwo.com"
-                target="_self"
+                style={{background: '#aaaaaa'}}
               >
                 Storefront
-              </a>
+              </div>
               <div className={styles.priceTierFeatures}>
                 <li>
                   <CheckCircle2 /> Application Market for your telco


### PR DESCRIPTION
> link to storefront.wgtwo.com is dead, so removing it

# [About/Demos](https://www.wgtwo.com/docs/about/demos/)
![image](https://github.com/working-group-two/wgtwo.com/assets/27897747/691d46f7-e202-482a-840b-899628a33d9c)

# [Product ecosystem](http://localhost:3000/product-ecosystem/)
![image](https://github.com/working-group-two/wgtwo.com/assets/27897747/3726b6f9-fa8c-47c3-9866-17c5b2e3e1bc)
