### PR TITLE
Infobar Restyled

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -28,10 +28,10 @@ module.exports = {
     announcementBar: {
       id: "announcement-bar",
       content:
-        '<b>Cisco announces intent to acquire Working Group Two</b> - <a target="_blank" href="/blog/cisco-intends-to-acquire-wg2">read more →</a>',
-      backgroundColor: "#B2E5FB",
-      textColor: "#2A3033",
-      isCloseable: true,
+        '<a class="announcementBarLinkContainer" target="_blank" href="https://blogs.cisco.com/news/cisco-announces-intent-to-acquire-working-group-two"><img src="/img/cisco.png"><b>Working Group Two is now part of Cisco</b><span class="separator"> | </span><span>Learn more →</span></a>',
+      backgroundColor: "#000000",
+      textColor: "#b8b8b8",
+      isCloseable: false,
     },
     metadata: [
       {
@@ -291,6 +291,7 @@ module.exports = {
             require.resolve("./src/css/general.css"),
             require.resolve("./src/css/markdown.css"),
             require.resolve("./src/css/nav.css"),
+            require.resolve("./src/css/announcement-bar.css"),
           ],
         },
       },

--- a/website/src/css/announcement-bar.css
+++ b/website/src/css/announcement-bar.css
@@ -1,0 +1,47 @@
+div[role="banner"] {
+  height: auto;
+}
+
+div[role="banner"] > div:last-of-type {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+div[role="banner"] > div:last-of-type > .announcementBarLinkContainer {
+  padding: 18px 20px;
+  text-decoration: none;
+  flex-grow: 1;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+
+  transition: background-color 200ms ease;
+}
+div[role="banner"] > div:last-of-type > .announcementBarLinkContainer:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+div[role="banner"] > div:last-of-type > .announcementBarLinkContainer > img {
+  height: 35px;
+  margin-right: 2px;
+}
+
+@media (max-width: 500px) {
+  div[role="banner"] > div:last-of-type > .announcementBarLinkContainer {
+    padding: 10px 20px;
+    flex-direction: column;
+    gap: 0px;
+  }
+
+  div[role="banner"] > div:last-of-type > .announcementBarLinkContainer > img {
+    height: 30px;
+    margin-bottom: 5px;
+  }
+
+  div[role="banner"] .separator {
+    display: none;
+  }
+}


### PR DESCRIPTION
![Screenshot_2830](https://github.com/working-group-two/wgtwo.com/assets/27897747/45566906-7883-46c7-bf79-e8fdb08a4da3)

![Screenshot_2831](https://github.com/working-group-two/wgtwo.com/assets/27897747/e77ce354-0494-4f9e-bf50-16a815abef23)

### Whole bar is clickable :)

*May* break if the infobar's `role="banner"` property is changed somehow, which is quite unlikely. But in such case, simply switch to targeting `div[class^='announcementBar']`